### PR TITLE
shiftavr-examples: examples and code optimizations for libuart and libadc

### DIFF
--- a/helper-scripts/abstract/abstract-upload.sh
+++ b/helper-scripts/abstract/abstract-upload.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+function convertToHex() {
+     local AVR_HOME=${1}
+     local elf=${2} 
+     local directory=${3}
+     
+     temp=$(pwd)
+     cd ${directory}   
+  	 ${AVR_HOME}'/bin/avr-objcopy' -O ihex ${elf} ${elf}'.hex'
+  	 cd $temp
+	 return $?
+}
+
+function upload() {
+    local programmer=${1}
+    local baud_rate=${2}
+    local port=${3}
+    local chip=${4}
+    local flash_file=${5}
+    local directory=${6}
+    
+    temp=$(pwd)
+    cd ${directory}  
+	sudo avrdude -c ${programmer} -b${baud_rate} -P${port} -p${chip} -F -U flash:w:${flash_file}
+    cd $temp
+	return $?
+}

--- a/helper-scripts/project-impl/upload-to-chip.sh
+++ b/helper-scripts/project-impl/upload-to-chip.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source "./helper-scripts/abstract/abstract-upload.sh"
+source "./helper-scripts/project-impl/variables.sh"
+
+elf=${1}
+directory=${2}
+
+convertToHex ${AVR_HOME} ${elf} ${directory}
+upload ${PROGRAMMER} ${BAUD_RATE} ${PORT} ${CHIP_ALIAS} ${elf} ${directory}

--- a/helper-scripts/project-impl/variables.sh
+++ b/helper-scripts/project-impl/variables.sh
@@ -13,3 +13,9 @@ source_dir="$project_root/shiftavr-core/"
 examples_dir="$project_root/shiftavr-examples/"
 
 
+# AVR-DUDE properties
+BAUD_RATE='57600'
+PORT='/dev/ttyUSB0'
+CHIP='atmega328p'
+CHIP_ALIAS='m328p'
+PROGRAMMER='arduino'

--- a/shiftavr-core/CMakeLists.txt
+++ b/shiftavr-core/CMakeLists.txt
@@ -16,10 +16,10 @@ set(COMPILER_OPTIONS "-mmcu=${TARGET}")
 
 set(avr_headers "${AVR_HOME}/avr/include/")
 
-set(libuart "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/start.c"
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/stop.c"
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/receiver_isr.c"
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/transmitter_isr.c"
+set(libuart "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/uart_start_protocol.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/uart_stop_protocol.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/uart_receiver_isr.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/uart_transmitter_isr.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/udr_reset_isr.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/udr_cprint.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/libuart/udr_cprintln.c"

--- a/shiftavr-core/src/include/adc/adc.h
+++ b/shiftavr-core/src/include/adc/adc.h
@@ -5,8 +5,7 @@
  * @version 0.1
  * @date 2022-07-04
  * 
- * @copyright Copyright (c) 2022
- * 
+ * @copyright The AVR-Sandbox Project, Copyright (c) 2022
  */
 #ifndef _ADC_H
 #define _ADC_H 
@@ -27,6 +26,30 @@
 #define ADC_MUX7 (ADC_MUX6 + 0x01)
 
 /**
+ * @brief Callbacks for the uart protocol, use the struct initializer to instantiate these pointers.
+ */
+typedef struct {
+    /**
+     * @brief Disptached when the adc interrupt is reached.
+     * @note Make sure to enable the adc isr before using.
+     *       Make sure to implement this method locally on your source file.
+     */
+    void (*adc_on_received)(const uint16_t READ);
+    void (*adc_on_start_protocol)();
+    void (*adc_on_stop_protocol)();
+    void (*adc_on_start_conversion)();
+} adc_callbacks;
+
+/**
+ * Interrupt-safe re-assignable callbacks.
+ */
+volatile adc_callbacks* adc_internal_callbacks;
+
+static inline void adc_assign_callbacks(volatile adc_callbacks* in_callbacks) {
+    adc_internal_callbacks = in_callbacks;
+}
+
+/**
  * @brief Starts the ADC protocol and enable the adc interrupt service by setting the [ADEN] and [ADIE].
  */
 void adc_start_protocol();
@@ -42,13 +65,6 @@ void adc_stop_protocol();
 void adc_enable_isr();
 
 /**
- * @brief Disptached when the adc interrupt is reached.
- * @note Make sure to enable the adc isr before using.
- *       Make sure to implement this method locally on your source file.
- */
-void adc_on_received(const uint16_t READ);
-
-/**
  * @brief Starts the Analog to Digital conversion.
  * @note When setting the bit [ADIE] on the [ADCSRA] register, an interrupt service is fired once the conversion is completed.
  * @param PIN the ADC MUX pin to read from.
@@ -61,6 +77,6 @@ void adc_start_conversion(const uint8_t PIN);
  * 
  * @return uint16_t a new 16-bit register representing 10-bit decade data output from the ADC.
  */
-uint16_t adc_read();
+volatile uint16_t adc_read();
 
 #endif

--- a/shiftavr-core/src/libadc/adc_conversion_isr.c
+++ b/shiftavr-core/src/libadc/adc_conversion_isr.c
@@ -4,9 +4,11 @@
  * @brief An interrupt service handler, fired when the ADC conversion completes.
  */
 ISR(ADC_vect) { 
-    volatile uint8_t adcl = ADCL; /* ADCL must be read before ADCH */
-    volatile uint8_t adch = ADCH; 
-    adc_on_received(((0x00 | adch) << 8) | adcl);
+    if (adc_internal_callbacks != NULL && adc_internal_callbacks->adc_on_received != NULL) {
+        volatile uint8_t adcl = ADCL; /* ADCL must be read before ADCH */
+        volatile uint8_t adch = ADCH; 
+        adc_internal_callbacks->adc_on_received(((0x00 | adch) << 8) | adcl);
+    }
 }
 
 void adc_enable_isr() {

--- a/shiftavr-core/src/libadc/adc_read.c
+++ b/shiftavr-core/src/libadc/adc_read.c
@@ -1,6 +1,6 @@
 #include<adc/adc.h>
 
-uint16_t adc_read() { 
+volatile uint16_t adc_read() { 
     volatile uint8_t adcl = ADCL; /* ADCL must be read before ADCH */
     volatile uint8_t adch = ADCH;
     return ((0x00 | adch) << 8) | adcl; /* concatenate the 2 (8-bit registers) in a 16-bit software register */

--- a/shiftavr-core/src/libadc/adc_start_conversion.c
+++ b/shiftavr-core/src/libadc/adc_start_conversion.c
@@ -4,4 +4,7 @@ void adc_start_conversion(const uint8_t PIN) {
     /* setup ADMUX */
     ADMUX = 0b01000000 | PIN; /* 1 for REFS0 for (VREF = VCC) */
     ADCSRA |= (1 << ADSC); /* the last step: start conversion */
+    if (adc_internal_callbacks != NULL && adc_internal_callbacks->adc_on_start_conversion != NULL) {
+        adc_internal_callbacks->adc_on_start_conversion();
+    }
 }

--- a/shiftavr-core/src/libadc/adc_start_protocol.c
+++ b/shiftavr-core/src/libadc/adc_start_protocol.c
@@ -14,4 +14,8 @@ void adc_start_protocol() {
     /* setup ADCSRA */
     ADCSRA = (1 << ADEN) /*enable adc protocol*/ | (1 << ADPS2) | 
              (1 << ADPS1) | (1 << ADPS0) /*set clock prescaler to clk/128*/; 
+
+    if (adc_internal_callbacks != NULL && adc_internal_callbacks->adc_on_start_protocol != NULL) {
+        adc_internal_callbacks->adc_on_start_protocol();
+    }
 }

--- a/shiftavr-core/src/libadc/adc_stop_protocol.c
+++ b/shiftavr-core/src/libadc/adc_stop_protocol.c
@@ -4,5 +4,8 @@ void adc_stop_protocol() {
     ADCH = 0x00;
     ADCL = 0x00;
     ADCSRA = 0x00; /* format the control status register A including the [ADEN] bit */
+    if (adc_internal_callbacks != NULL && adc_internal_callbacks->adc_on_stop_protocol != NULL) {
+        adc_internal_callbacks->adc_on_stop_protocol();
+    }
 }
 

--- a/shiftavr-core/src/libuart/start.c
+++ b/shiftavr-core/src/libuart/start.c
@@ -1,9 +1,0 @@
-#include<uart/uart.h>
-
-void startProtocol(const uint16_t BAUD_RATE_VAL) {
-    REG_UCSRB = (1 << BIT_TXEN) | (1 << BIT_RXEN); /* enable the transmit and receiver buffers and their interrupt services */
-    REG_UCSRC = (1 << BIT_USBS) | (3 << BIT_UCSZ0); // enables the UCSZ0, UCSZ1 and URSEL
-    REG_UBRR = BAUD_RATE_VAL; // 0x10 (16) for BR = 57600 // 0x33 (51) for 9600
-    onProtocolStarted();
-    startReceiverISR();
-}

--- a/shiftavr-core/src/libuart/stop.c
+++ b/shiftavr-core/src/libuart/stop.c
@@ -1,6 +1,0 @@
-#include<uart/uart.h>
-
-void stopProtocol() {
-    onProtocolStopped();
-    REG_UCSRB = 0x00; 
-}

--- a/shiftavr-core/src/libuart/uart_receiver_isr.c
+++ b/shiftavr-core/src/libuart/uart_receiver_isr.c
@@ -4,16 +4,18 @@
  * @brief Triggered when the RXC0 is settled and the receiving has been completed.
  */
 ISR (__vector_USART_RX) {
-    onDataReceiveCompleted((const uint8_t) REG_UDR);
+    if (uart_internal_callbacks != NULL && uart_internal_callbacks->on_data_receive_completed != NULL) {
+        uart_internal_callbacks->on_data_receive_completed((const uint8_t) REG_UDR);
+    }
 }
 
-void startReceiverISR() {
+void uart_start_receiver_isr() {
     REG_UCSRB |= (1 << BIT_RXCIE);
     /* start the interrupt service handlers */
     sei();
 }
 
-void stopReceiverISR() {
+void uart_stop_receiver_isr() {
     // Finds the 1s complement of all bits in RXCIE0 ---> eg: 0b11111101
     REG_UCSRB &= ~(1 << BIT_RXCIE); 
 }

--- a/shiftavr-core/src/libuart/uart_start_protocol.c
+++ b/shiftavr-core/src/libuart/uart_start_protocol.c
@@ -1,0 +1,11 @@
+#include<uart/uart.h>
+
+void uart_start_protocol(const uint16_t BAUD_RATE_VAL) {
+    REG_UCSRB = (1 << BIT_TXEN) | (1 << BIT_RXEN); /* enable the transmit and receiver buffers */
+    REG_UCSRC = (1 << BIT_USBS) | (3 << BIT_UCSZ0); // enables the UCSZ0, UCSZ1 and URSEL
+    REG_UBRR = BAUD_RATE_VAL; // 0x10 (16) for BR = 57600 // 0x33 (51) for 9600
+
+    if (uart_internal_callbacks != NULL && uart_internal_callbacks->on_protocol_started != NULL) {
+        uart_internal_callbacks->on_protocol_started();
+    }
+}

--- a/shiftavr-core/src/libuart/uart_stop_protocol.c
+++ b/shiftavr-core/src/libuart/uart_stop_protocol.c
@@ -1,0 +1,8 @@
+#include<uart/uart.h>
+
+void uart_stop_protocol() {
+    REG_UCSRB = 0x00; 
+    if (uart_internal_callbacks != NULL && uart_internal_callbacks->on_protocol_stopped != NULL) {
+        uart_internal_callbacks->on_protocol_stopped();
+    }
+}

--- a/shiftavr-core/src/libuart/uart_transmitter_isr.c
+++ b/shiftavr-core/src/libuart/uart_transmitter_isr.c
@@ -4,17 +4,18 @@
  * @brief Triggered when the bit TXC is settled and the data transmission has been completed.
  */
 ISR (__vector_USART_TX) {
-    onDataTransmitCompleted((const uint8_t) REG_UDR);
-    stopTransmitterISR();
+    if (uart_internal_callbacks != NULL && uart_internal_callbacks->on_data_transmission_completed != NULL) {
+        uart_internal_callbacks->on_data_transmission_completed((const uint8_t) REG_UDR);
+    }
 }
 
-void startTransmitterISR() {
+void uart_start_transmitter_isr() {
     REG_UCSRB |= (1 << BIT_TXCIE);
     /* start the interrupt service handlers */
     sei();
 }
 
-void stopTransmitterISR() {
+void uart_stop_transmitter_isr() {
     // Finds the 1s complement of all bits in RXCIE0 ---> eg: 0b11111101
     REG_UCSRB &= ~(1 << BIT_TXCIE); 
 }

--- a/shiftavr-core/src/libuart/udr_cprint.c
+++ b/shiftavr-core/src/libuart/udr_cprint.c
@@ -1,7 +1,6 @@
 #include<uart/uart.h>
 
-void cprint(char* data) {
+void uart_cprint(char data) {
     while (!(REG_UCSRA & (1 << BIT_UDRE)));
-    REG_UDR = *data;
-    startTransmitterISR();
+    REG_UDR = data;
 }

--- a/shiftavr-core/src/libuart/udr_cprintln.c
+++ b/shiftavr-core/src/libuart/udr_cprintln.c
@@ -1,6 +1,6 @@
 #include<uart/uart.h>
 
-void cprintln(char* data) {
-    cprint(data);
-    sprint(NEW_LINE_CARRIAGE_R);
+void uart_cprintln(char data) {
+    uart_cprint(data);
+    uart_sprint(NEW_LINE_CARRIAGE_R);
 }

--- a/shiftavr-core/src/libuart/udr_plain_io.c
+++ b/shiftavr-core/src/libuart/udr_plain_io.c
@@ -1,12 +1,6 @@
 #include<uart/uart.h>
 
-void setTransmitDataRegister(const uint8_t* ptransmitData) {
-    *(transmitData) = *ptransmitData;
-    startDataRegisterEmptyBufferISR();
-    startTransmitterISR();
-}
-
-uint8_t readASCII() {
+volatile uint8_t uart_poll_read_ascii() {
     while (!(REG_UCSRA & (1 << BIT_RXC)));
     return REG_UDR;
 }

--- a/shiftavr-core/src/libuart/udr_print.c
+++ b/shiftavr-core/src/libuart/udr_print.c
@@ -1,12 +1,11 @@
 #include<uart/uart.h>
 
-void print(const int64_t data, const uint8_t base) {
-    char* strBuffer = allocateStringBuffer();
+void uart_print(const int64_t data, const uint8_t base) {
+    char* str = allocate_buffer_address();
     // convert input to string
-    itoa(data, strBuffer, base);
-    int i = 0;
-    while (i < strlen(strBuffer)) {
-        cprint(&strBuffer[i++]);
+    itoa(data, str, base);
+    for (int i = 0; i < strlen(str); i++) {
+        uart_cprint(str[i]);
     }
-    free(strBuffer);
+    free(str);
 }

--- a/shiftavr-core/src/libuart/udr_println.c
+++ b/shiftavr-core/src/libuart/udr_println.c
@@ -1,6 +1,6 @@
 #include<uart/uart.h>
 
-void println(const int64_t data, const uint8_t base) {
-    print(data, base);
-    sprint(NEW_LINE_CARRIAGE_R);
+void uart_println(const int64_t data, const uint8_t base) {
+    uart_print(data, base);
+    uart_sprint(NEW_LINE_CARRIAGE_R);
 }

--- a/shiftavr-core/src/libuart/udr_reset_isr.c
+++ b/shiftavr-core/src/libuart/udr_reset_isr.c
@@ -4,18 +4,18 @@
  * @brief Triggered when the bit UDRE0 is one (the data register buffer is empty and ready to send data).
  */
 ISR (USART_UDRE_vect) {
-    REG_UDR = *(transmitData);
-    onDataBufferCleared((const uint8_t*) transmitData);
-    stopDataRegisterEmptyBufferISR();
+    if (uart_internal_callbacks != NULL && uart_internal_callbacks->on_databuffer_cleared != NULL) {
+        uart_internal_callbacks->on_databuffer_cleared();
+    }
 }
 
-void startDataRegisterEmptyBufferISR() {
+void uart_start_udre_isr() {
     REG_UCSRB |= (1 << BIT_UDRIE);
     /* start the interrupt service handlers */
     sei();
 }
 
-void stopDataRegisterEmptyBufferISR() {
+void uart_stop_udre_isr() {
     // Finds the 1s complement of all bits in UDRIE0 ---> eg: 0b11111101
     REG_UCSRB &= ~(1 << BIT_UDRIE); 
 }

--- a/shiftavr-core/src/libuart/udr_sprint.c
+++ b/shiftavr-core/src/libuart/udr_sprint.c
@@ -1,8 +1,8 @@
 #include<uart/uart.h>
 
-void sprint(char* data) {
+void uart_sprint(char* data) {
     int i = 0;
     while (i < strlen(data)) {
-        cprint(&data[i++]);
+        uart_cprint(data[i++]);
     }
 }

--- a/shiftavr-core/src/libuart/udr_sprintln.c
+++ b/shiftavr-core/src/libuart/udr_sprintln.c
@@ -1,6 +1,6 @@
 #include<uart/uart.h>
 
-void sprintln(char* data) {
-    sprint(data);
-    sprint(NEW_LINE_CARRIAGE_R);
+void uart_sprintln(char* data) {
+    uart_sprint(data);
+    uart_sprint(NEW_LINE_CARRIAGE_R);
 }

--- a/shiftavr-examples/CMakeLists.txt
+++ b/shiftavr-examples/CMakeLists.txt
@@ -14,7 +14,7 @@ set(elf "${EXAMPLE}.elf")
 
 set(CMAKE_C_COMPILER "${AVR_HOME}/bin/avr-gcc")
 set(CMAKE_CXX_COMPILER "${AVR_HOME}/bin/avr-g++")
-set(COMPILER_OPTIONS "-mmcu=${TARGET}")
+set(COMPILER_OPTIONS "-mmcu=${TARGET} -O3")
 
 set(headers "${SHIFT_AVR}src/include")
 set(avr_headers "${AVR_HOME}/include")

--- a/shiftavr-examples/src/hello_adc.c
+++ b/shiftavr-examples/src/hello_adc.c
@@ -1,15 +1,66 @@
+#define F_CPU 16000000UL
 #include <adc/adc.h>
+#include <uart/uart.h>
+#include <util/delay.h>
 
-void adc_on_received(const uint16_t READ) {
-    // do stuff
-    // restart the adc conversion
-    adc_start_conversion(ADC_MUX0);
-}
+void adc_on_received(const uint16_t);
+void adc_on_protocol_started();
+void on_data_received(const uint8_t);
+void on_data_transmitted(const uint8_t);
 
-int main() {
+static inline void setup_adc() {
     adc_start_protocol();
     adc_enable_isr();
     adc_start_conversion(ADC_MUX0);
+}
+
+static inline void setup_uart() {
+    uart_start_protocol(BAUD_RATE_57600);
+}
+
+void adc_on_received(const uint16_t READ) {
+    // do stuff
+    uart_println(READ, 10);
+    // restart the adc conversion
+    setup_adc();
+}
+
+void adc_on_protocol_started() {
+}
+
+void on_data_received(const uint8_t datum) {
+}
+
+void on_data_transmitted(const uint8_t datum) {
+}
+
+/**
+ * @note volatile: marks this object as an interrupt-safe adjustable. 
+ */
+volatile adc_callbacks _adc_callbacks = {
+    adc_on_received,
+    NULL,
+    NULL,
+    NULL,
+};
+
+/**
+ * @note volatile: marks this object as an interrupt-safe adjustable. 
+ */
+volatile uart_callbacks _uart_callbacks = {
+    NULL, 
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+int main() {
+    adc_assign_callbacks(&_adc_callbacks);
+    uart_assign_callbacks(&_uart_callbacks);
+    setup_uart();
+    setup_adc();
+    
     while (1); /* Running forever! */
 	return 0;
 }

--- a/shiftavr-examples/src/hello_uart.c
+++ b/shiftavr-examples/src/hello_uart.c
@@ -1,14 +1,48 @@
+#define F_CPU 16000000UL
 #include <uart/uart.h>
 
-void onProtocolStarted() {
-
+void on_protocol_started() {
 }
 
-void onDataReceiveCompleted(const uint8_t s)  {
+void on_protocol_stopped() {
 }
+
+void on_data_received(const uint8_t datum) {
+    uart_cprint(datum);
+    uart_start_transmitter_isr();
+    uart_start_udre_isr();
+}
+
+void on_data_transmitted(const uint8_t datum) {
+    uart_stop_transmitter_isr();
+    uart_start_udre_isr();
+}
+
+void on_databuffer_cleared() {
+    uart_stop_udre_isr();
+}
+
+/**
+ * @note volatile: marks this object as an interrupt-safe adjustable. 
+ */
+volatile uart_callbacks _uart_callbacks = {
+    on_protocol_started,
+    on_protocol_stopped,
+    on_data_received,
+    on_data_transmitted,
+    on_databuffer_cleared
+};
 
 int main() {
-    startProtocol(2230);
+    /* assigns api callbacks */
+    uart_assign_callbacks(&_uart_callbacks);
+    /* start the protocol first to enable TX and RX and set BAUD! */
+    uart_start_protocol(BAUD_RATE_57600);
+    /* starting the ISR should be after starting the protocol! i.e, after enabling RX and TX! */
+    uart_start_udre_isr();
+    uart_start_receiver_isr();
+    uart_start_transmitter_isr();
+
     while (1); /* Running forever! */
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
## This PR adds the following:
- [x] Optimizations to the core `libuart` and `libadc`.
- [x] Complete example for `libuart`.
- [x] Complete example for `libadc` along with UART debugging.
- [x] Upload example-chooser script. 