### PR TITLE
shift-avr: adc parts and docs enhances

### DIFF
--- a/shiftavr-core/src/include/adc/adc.h
+++ b/shiftavr-core/src/include/adc/adc.h
@@ -10,23 +10,28 @@
 #ifndef _ADC_H
 #define _ADC_H 
 
+/* Internal libraries used by [adc.h]! */
 #include<avr/io.h>
 #include<avr/interrupt.h>
 #include<string.h>
 #include<stdlib.h>
 
-/* define analog ADC pins based on the multiplexers codes */
-#define ADC_MUX0 ((const uint8_t) 0x00)
-#define ADC_MUX1 (ADC_MUX0 + 0x01)
-#define ADC_MUX2 (ADC_MUX1 + 0x01)
-#define ADC_MUX3 (ADC_MUX2 + 0x01)
-#define ADC_MUX4 (ADC_MUX3 + 0x01)
-#define ADC_MUX5 (ADC_MUX4 + 0x01)
-#define ADC_MUX6 (ADC_MUX5 + 0x01)
-#define ADC_MUX7 (ADC_MUX6 + 0x01)
+/* ADC pre-defined library parts! */
+#include<adc/control/clkprescaler.h>
+#include<adc/admux/channel.h>
+#include<adc/admux/vref.h>
 
 /**
  * @brief Callbacks for the uart protocol, use the struct initializer to instantiate these pointers.
+ * @example 
+ * volatile adc_callbacks _adc_callbacks = {
+ *     adc_on_received,
+ *      NULL,
+ *      NULL,
+ *      NULL,
+ *  };
+ * ...
+ * int main() { adc_assign_callbacks(&_adc_callbacks); ... while (1); }
  */
 typedef struct {
     /**
@@ -41,10 +46,15 @@ typedef struct {
 } adc_callbacks;
 
 /**
- * Interrupt-safe re-assignable callbacks.
+ * @brief Interrupt-safe re-assignable callbacks.
  */
 volatile adc_callbacks* adc_internal_callbacks;
 
+/**
+ * @brief Assigns the callbacks for the ADC conversion.
+ * 
+ * @param in_callbacks an interrupt-safe adc callback object.
+ */
 static inline void adc_assign_callbacks(volatile adc_callbacks* in_callbacks) {
     adc_internal_callbacks = in_callbacks;
 }
@@ -67,9 +77,13 @@ void adc_enable_isr();
 /**
  * @brief Starts the Analog to Digital conversion.
  * @note When setting the bit [ADIE] on the [ADCSRA] register, an interrupt service is fired once the conversion is completed.
+ * 
  * @param PIN the ADC MUX pin to read from.
+ * @param V_REF the reference voltage to use for the ADC, 
+ *              the reference voltage represents the voltage to compare against.
+ * @param CONVERSION_SPEED the speed of the adc conversion in relation to the crystal oscillator.
  */
-void adc_start_conversion(const uint8_t PIN);
+void adc_start_conversion(const uint8_t PIN, const uint8_t V_REF, const uint8_t CONVERSION_SPEED);
 
 /**
  * @brief Combines the readings of [ADCL] and [ADCH] data registers in a 16-bit software register.

--- a/shiftavr-core/src/include/adc/admux/channel.h
+++ b/shiftavr-core/src/include/adc/admux/channel.h
@@ -1,0 +1,48 @@
+/**
+ * @brief Defines analog ADC pins using channels [0-7] based on the multiplexers codes.
+ * @author pavl_g 
+ */
+#ifndef _CHANNEL_H
+#define _CHANNEL_H
+
+/**
+ * @brief The AVR ADC Channel-0. 
+ */
+#define ADC_MUX0 ((const uint8_t) 0x00)
+
+/**
+ * @brief The AVR ADC Channel-1. 
+ */
+#define ADC_MUX1 (ADC_MUX0 + 0x01)
+
+/**
+ * @brief The AVR ADC Channel-2. 
+ */
+#define ADC_MUX2 (ADC_MUX1 + 0x01)
+
+/**
+ * @brief The AVR ADC Channel-3. 
+ */
+#define ADC_MUX3 (ADC_MUX2 + 0x01)
+
+/**
+ * @brief The AVR ADC Channel-4. 
+ */
+#define ADC_MUX4 (ADC_MUX3 + 0x01)
+
+/**
+ * @brief The AVR ADC Channel-5. 
+ */
+#define ADC_MUX5 (ADC_MUX4 + 0x01)
+
+/**
+ * @brief The AVR ADC Channel-6. 
+ */
+#define ADC_MUX6 (ADC_MUX5 + 0x01)
+
+/**
+ * @brief The AVR ADC Channel-7. 
+ */
+#define ADC_MUX7 (ADC_MUX6 + 0x01)
+
+#endif

--- a/shiftavr-core/src/include/adc/admux/vref.h
+++ b/shiftavr-core/src/include/adc/admux/vref.h
@@ -1,0 +1,23 @@
+/**
+ * @brief Provides the supported flags for the analog converter voltage reference.
+ * @author pavl_g. 
+ */
+#ifndef _V_REF_H
+#define _V_REF_H
+
+/**
+ * @brief use the external AREF pin as a voltage reference, internal V-REF turned off. 
+ */
+#define EXTERNAL_VREF ((const uint8_t) 0x00)
+
+/**
+ * @brief use AV(CC) with external capacitor at AREF pin.
+ */
+#define AVCC_VREF ((const uint8_t) 1 << REFS0)
+
+/**
+ * @brief use the internal 1.1V voltage reference with external capacitor at AREF pin, 
+ */
+#define INTERNAL_VREF ((const uint8_t) AVCC_VREF | (1 << REFS1))
+
+#endif

--- a/shiftavr-core/src/include/adc/control/clkprescaler.h
+++ b/shiftavr-core/src/include/adc/control/clkprescaler.h
@@ -1,0 +1,45 @@
+/** 
+ * @brief Defines clock pre-scalers to adjust the speed of conversionn based on the crystal oscillator.
+ * @author pavl_g
+ * @note  For the AVR, the ADC requires an input clk frequency less than 200kHz 
+ *        for the maximum accuracy.
+ */
+#ifndef _CLK_PRESCALER_H
+#define _CLK_PRESCALER_H
+
+/**
+ * @brief Scales the speed to CLK/2, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_2 ((const uint8_t) 1 << ADPS0)
+
+/**
+ * @brief Scales the speed to CLK/4, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_4 ((const uint8_t) 1 << ADPS1)
+
+/**
+ * @brief Scales the speed to CLK/8, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_8 ((const uint8_t) CLK_2 | CLK_4)
+
+/**
+ * @brief Scales the speed to CLK/16, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_16 ((const uint8_t) 1 << ADPS2)
+
+/**
+ * @brief Scales the speed to CLK/32, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_32 ((const uint8_t) CLK_16 | CLK_2)
+
+/**
+ * @brief Scales the speed to CLK/64, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_64 ((const uint8_t) CLK_16 | CLK_4)
+
+/**
+ * @brief Scales the speed to CLK/128, where [CLK] is the speed of the crystal oscillator. 
+ */
+#define CLK_128 ((const uint8_t) CLK_2 | CLK_4 | CLK_16)
+
+#endif

--- a/shiftavr-core/src/libadc/adc_start_conversion.c
+++ b/shiftavr-core/src/libadc/adc_start_conversion.c
@@ -1,9 +1,11 @@
 #include<adc/adc.h>
 
-void adc_start_conversion(const uint8_t PIN) {
+void adc_start_conversion(const uint8_t PIN, const uint8_t V_REF, const uint8_t CONVERSION_SPEED) {
     /* setup ADMUX */
-    ADMUX = 0b01000000 | PIN; /* 1 for REFS0 for (VREF = VCC) */
+    ADCSRA |= CONVERSION_SPEED;
+    ADMUX = V_REF | PIN; 
     ADCSRA |= (1 << ADSC); /* the last step: start conversion */
+    
     if (adc_internal_callbacks != NULL && adc_internal_callbacks->adc_on_start_conversion != NULL) {
         adc_internal_callbacks->adc_on_start_conversion();
     }

--- a/shiftavr-core/src/libadc/adc_start_protocol.c
+++ b/shiftavr-core/src/libadc/adc_start_protocol.c
@@ -12,8 +12,7 @@
 
 void adc_start_protocol() {
     /* setup ADCSRA */
-    ADCSRA = (1 << ADEN) /*enable adc protocol*/ | (1 << ADPS2) | 
-             (1 << ADPS1) | (1 << ADPS0) /*set clock prescaler to clk/128*/; 
+    ADCSRA = (1 << ADEN) /*enable adc protocol*/; 
 
     if (adc_internal_callbacks != NULL && adc_internal_callbacks->adc_on_start_protocol != NULL) {
         adc_internal_callbacks->adc_on_start_protocol();

--- a/shiftavr-core/wiki/libadc/README.md
+++ b/shiftavr-core/wiki/libadc/README.md
@@ -121,8 +121,8 @@ void adc_on_received(const uint16_t READ) {
 int main() {
     adc_start_protocol();
     adc_enable_isr();
-    // start conversion on adc channel 0
-    adc_start_conversion(ADC_MUX0);
+    // start conversion on [adc channel 0] with the [AREF = VCC] and Conversion speed = CLK/16
+    adc_start_conversion(ADC_MUX0, AVCC_VREF, CLK_16);
     while (1); /* Running forever! */
 }
 ```
@@ -134,7 +134,7 @@ int main() {
 void adc_on_received(const uint16_t READ) {
     // do stuff
     // restart conversion 
-    adc_start_conversion(ADC_MUX0);
+    adc_start_conversion(ADC_MUX0, AVCC_VREF, CLK_16);
 }
 
 int main() {

--- a/shiftavr-examples/src/hello_adc.c
+++ b/shiftavr-examples/src/hello_adc.c
@@ -8,21 +8,11 @@ void adc_on_protocol_started();
 void on_data_received(const uint8_t);
 void on_data_transmitted(const uint8_t);
 
-static inline void setup_adc() {
-    adc_start_protocol();
-    adc_enable_isr();
-    adc_start_conversion(ADC_MUX0);
-}
-
-static inline void setup_uart() {
-    uart_start_protocol(BAUD_RATE_57600);
-}
-
 void adc_on_received(const uint16_t READ) {
     // do stuff
     uart_println(READ, 10);
     // restart the adc conversion
-    setup_adc();
+    adc_start_conversion(ADC_MUX0, AVCC_VREF, CLK_16);
 }
 
 void adc_on_protocol_started() {
@@ -56,11 +46,16 @@ volatile uart_callbacks _uart_callbacks = {
 };
 
 int main() {
-    adc_assign_callbacks(&_adc_callbacks);
+    /* setup UART! */
     uart_assign_callbacks(&_uart_callbacks);
-    setup_uart();
-    setup_adc();
-    
+    uart_start_protocol(BAUD_RATE_57600);
+
+    /* setup ADC! */
+    adc_assign_callbacks(&_adc_callbacks);
+    adc_start_protocol();
+    adc_enable_isr();
+    adc_start_conversion(ADC_MUX0, AVCC_VREF, CLK_16);
+
     while (1); /* Running forever! */
 	return 0;
 }

--- a/shiftavr-examples/src/hello_adc.c
+++ b/shiftavr-examples/src/hello_adc.c
@@ -57,5 +57,5 @@ int main() {
     adc_start_conversion(ADC_MUX0, AVCC_VREF, CLK_16);
 
     while (1); /* Running forever! */
-	return 0;
+    return 0;
 }


### PR DESCRIPTION
## This PR adds the following:
- [x] Separated ADC macros as ADC parts to meet the library standard.
- [x] Simplified the ADC example.