### PR TITLE
shiftavr: lipgpio and gpio examples

### DIFF
--- a/shiftavr-core/CMakeLists.txt
+++ b/shiftavr-core/CMakeLists.txt
@@ -35,10 +35,18 @@ set(libadc "${CMAKE_CURRENT_SOURCE_DIR}/src/libadc/adc_start_protocol.c"
            "${CMAKE_CURRENT_SOURCE_DIR}/src/libadc/adc_read.c"
            "${CMAKE_CURRENT_SOURCE_DIR}/src/libadc/adc_conversion_isr.c")
 
+set(libgpio "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/gpio_read.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/gpio_fastread.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/gpio_write.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/port/part/gpio_part.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/gpio_write.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/gpio_toggle_pin_pullup.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/libgpio/gpio_toggle_universal_pullup.c")
+
 set(headers "${avr_headers}"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/include/")
 
-set(sources ${libuart} ${libadc})
+set(sources ${libuart} ${libadc} ${libgpio}) 
 
 # add a library target
 add_library(${library} STATIC ${sources})

--- a/shiftavr-core/src/include/gpio/gpio.h
+++ b/shiftavr-core/src/include/gpio/gpio.h
@@ -1,0 +1,78 @@
+/**
+ * @brief The main header entry for the GPIO drivers. 
+ * @author pavl_g.
+ * @copyright
+ */
+#ifndef _GPIO_H_
+#define _GPIO_H_
+
+/* Internal libraries used by [gpio.h]! */
+#include<avr/io.h>
+#include<avr/interrupt.h>
+
+/* Internal use-only! */
+#include <gpio/port/port.h>
+#include <gpio/port/part/gpiopart.h>
+
+/**
+ * @brief Shortcut for PIN on state.
+ */
+#define ON ((const uint8_t) 0x01)
+
+/**
+ * @brief Shortcut for PIN off state.
+ */
+#define OFF ((const uint8_t) 0x00)
+
+/**
+ * @brief Initializes the device GPIO ports by assigning their I/O memory address locations (PORTx, DDRx and PINx).
+ */
+void gpio_initialize_ports();
+
+/**
+ * @brief Configures a port pin as output and toggles its state.
+ * 
+ * @param port the port to toggle its pin, e.g: {GPIO_PORTB}.
+ * @param pin the pin number in the [port] to toggle its state, e.g: {PB5}.
+ * @param state the state to assign to this port pin, either [ON] or [OFF].
+ */
+void gpio_write(const gpio_port port, const uint8_t pin, const uint8_t state);
+
+/**
+ * @brief Configures a port pin as input and reads its state with an initial pull-up resistor value. 
+ * 
+ * @param port the port to read its pin state, e.g: {GPIO_PORTB}.
+ * @param pin the pin number in the [port] to read its state, e.g: {PB5}.
+ * @param pullupresistor_state the initial pull-up resistor state, either [ON] or [OFF].
+ * @return an interrupt-safe 8-bit unsigned integer value representing the PINxn state, where [x] is the 
+ *         port and [n] is the address of the input pin on the port input register.
+ */
+volatile uint8_t gpio_read(const gpio_port port, const uint8_t pin, const uint8_t pullupresistor_state);
+
+/**
+ * @brief Reads a port pin state directly without an initial pull-up resistor state.
+ * 
+ * @param port the port to read its pin state, e.g: {GPIO_PORTB}.
+ * @param pin the pin number in the [port] to read its state, e.g: {PB5}.
+ * @return an interrupt-safe 8-bit unsigned integer value representing the PINxn state, where [x] is the 
+ *         port and [n] is the address of the input pin on the port input register.
+ */
+volatile uint8_t gpio_fastread(const gpio_port port, const uint8_t pin);
+
+/**
+ * @brief Configures a port pin as input and toggles its pull-up state.
+ *  
+ * @param port the port to toggle its pin pull-up, e.g: {GPIO_PORTB}.
+ * @param pin the pin number, e.g: {PB5}.
+ * @param pullupresistor_state a pull-up resistor state to assign to the specified port pin.
+ */
+void gpio_toggle_pin_pullup(const gpio_port port, const uint8_t pin, const uint8_t pullupresistor_state);
+
+/**
+ * @brief Toggles the PUD(Pull-up disable) bit.
+ * 
+ * @param state a state to assign either [ON] or [OFF].
+ */
+void gpio_toggle_universal_pullup(const uint8_t state);
+
+#endif 

--- a/shiftavr-core/src/include/gpio/port/part/gpiopart.h
+++ b/shiftavr-core/src/include/gpio/port/part/gpiopart.h
@@ -1,0 +1,19 @@
+/**
+ * @brief Defines dependent GPIO registers.
+ * @author pavl_g.
+ * @copyright
+ */
+#ifndef _GPIO_H_
+#   error "The <gpio/port/part/gpiopart.h> header is an internal property, include <gpio/gpio.h> instead of this!"
+#endif
+
+#ifndef _GPIO_PART_H_
+#define _GPIO_PART_H_
+
+#if defined (__AVR_ATmega32__)
+#  include <gpio/port/part/part-m32.h>
+#elif defined (__AVR_ATmega328P__)
+#  include <gpio/port/part/part-m328p.h>
+#endif
+
+#endif

--- a/shiftavr-core/src/include/gpio/port/part/part-m32.h
+++ b/shiftavr-core/src/include/gpio/port/part/part-m32.h
@@ -1,0 +1,41 @@
+/**
+ * @brief Defines GPIO ports for ATMega32.
+ * @author pavl_g.
+ * @copyright
+ */
+#ifndef _GPIO_H_
+#   error "The <gpio/port/part/part-m32.h> header is an internal property, include <gpio/gpio.h> instead of this!"
+#endif
+
+#ifndef _GPIO_PORT_PART_ATMEGA32_H_
+#define _GPIO_PORT_PART_ATMEGA32_H_
+
+#include <avr/io.h>
+#include <gpio/port/port.h>
+
+/**
+ * @brief A common Microcontroller-unit-control register alias to control PUD(Pull-Up-Disable) state.
+ */
+#define GPIO_MCUCR SFIOR
+
+/**
+ * @brief Prototype for PORTA registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTA;
+
+/**
+ * @brief Prototype for PORTB registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTB;
+
+/**
+ * @brief Prototype for PORTC registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTC;
+
+/**
+ * @brief Prototype for PORTD registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTD;
+
+#endif 

--- a/shiftavr-core/src/include/gpio/port/part/part-m328p.h
+++ b/shiftavr-core/src/include/gpio/port/part/part-m328p.h
@@ -1,0 +1,36 @@
+/**
+ * @brief Defines GPIO ports for ATMega328p.
+ * @author pavl_g.
+ * @copyright
+ */
+#ifndef _GPIO_H_
+#   error "The <gpio/port/part/part-m328p.h> header is an internal property, include <gpio/gpio.h> instead of this!"
+#endif
+
+#ifndef _GPIO_PORT_PART_ATMEGA328P_H_
+#define _GPIO_PORT_PART_ATMEGA328P_H_
+
+#include <avr/io.h>
+#include <gpio/port/port.h>
+
+/**
+ * @brief A common Microcontroller-unit-control register alias to control PUD(Pull-Up-Disable) state.
+ */
+#define GPIO_MCUCR MCUCR
+
+/**
+ * @brief Prototype for PORTB registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTB;
+
+/**
+ * @brief Prototype for PORTC registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTC;
+
+/**
+ * @brief Prototype for PORTD registers I/O memory addresses.
+ */
+gpio_port GPIO_PORTD;
+
+#endif 

--- a/shiftavr-core/src/include/gpio/port/port.h
+++ b/shiftavr-core/src/include/gpio/port/port.h
@@ -1,0 +1,35 @@
+/**
+ * @brief Defines the data structure for shift-avr port memory address locations system.
+ * @note Three I/O memory address locations are allocated for each port, one each for the data register – PORTx, data direction
+ *       register – DDRx, and the port input pins – PINx.
+ * @author pavl_g.
+ * @copyright
+ */
+#ifndef _GPIO_H_
+#   error "The <gpio/port/port.h> header is an internal property, include <gpio/gpio.h> instead of this!"
+#endif
+
+#ifndef _GPIO_PORT_H_
+#define _GPIO_PORT_H_
+
+/**
+ * @brief Defines a GPIO port with 3 I/O memory address locations, PORTx, DDRx and PINx.
+ */
+typedef struct {
+    /**
+     * @brief The memory address location for the data register [PORTx].
+     */
+    volatile uint8_t* PORTx;
+    
+    /**
+     * @brief The memory address location for the data direction register [DDRx].
+     */
+    volatile uint8_t* DDRx;
+    
+    /**
+     * @brief The memory address location for the port inputs register [PINx].
+     */
+    volatile uint8_t* PINx;
+} gpio_port;
+
+#endif

--- a/shiftavr-core/src/libgpio/gpio_fastread.c
+++ b/shiftavr-core/src/libgpio/gpio_fastread.c
@@ -1,0 +1,5 @@
+#include <gpio/gpio.h>
+
+volatile uint8_t gpio_fastread(const gpio_port port, const uint8_t pin) {
+    return *(port.PINx) & (1 << pin);
+}

--- a/shiftavr-core/src/libgpio/gpio_read.c
+++ b/shiftavr-core/src/libgpio/gpio_read.c
@@ -1,0 +1,10 @@
+#include <gpio/gpio.h>
+
+volatile uint8_t gpio_read(const gpio_port port, const uint8_t pin, const uint8_t pullupresistor_state) {
+    // setup the port as INPUT with pullup resistor
+    gpio_toggle_pin_pullup(port, pin, pullupresistor_state);
+    // synchronize read and write operations 
+    asm volatile ("nop");
+
+    return *(port.PINx) & (1 << pin);
+}

--- a/shiftavr-core/src/libgpio/gpio_toggle_pin_pullup.c
+++ b/shiftavr-core/src/libgpio/gpio_toggle_pin_pullup.c
@@ -1,0 +1,10 @@
+#include <gpio/gpio.h>
+
+void gpio_toggle_pin_pullup(const gpio_port port, const uint8_t pin, const uint8_t pullupresistor_state) {
+    // setup the port as INPUT
+    *(port.DDRx) &= ~(1 << pin);
+    // overwrite the pull-up resistor state at this pin 
+    const volatile uint8_t PORTxn_DISABLED = (*(port.PORTx) & ~(1 << pin));
+    const volatile uint8_t PINxn_STATE = (pullupresistor_state && 0xFF) << pin;
+    *(port.PORTx) = PORTxn_DISABLED | PINxn_STATE;
+}

--- a/shiftavr-core/src/libgpio/gpio_toggle_universal_pullup.c
+++ b/shiftavr-core/src/libgpio/gpio_toggle_universal_pullup.c
@@ -1,0 +1,6 @@
+#include <gpio/gpio.h>
+
+void gpio_toggle_universal_pullup(const uint8_t state) {
+    // flip the state and assign it to the pull-up disable bit on the MCUCR
+    GPIO_MCUCR |= ((1 << PUD) & ~state);
+}

--- a/shiftavr-core/src/libgpio/gpio_write.c
+++ b/shiftavr-core/src/libgpio/gpio_write.c
@@ -1,0 +1,16 @@
+#include <gpio/gpio.h>
+
+void gpio_write(const gpio_port port, const uint8_t pin, uint8_t state) {
+    *(port.DDRx) |= (1 << pin);
+    /* Recall, PORTx = 0b01100000
+       And, we want to change PINx4 to one
+       Then, 1) Disable PORTxn first, through [(*(port.PORTx) & (~(1 << pin))].
+             2) Add a state to PINxn, through [state << pin].
+             3) Apply the PINxn_STATE to the PORT via [PORTxn_DISABLED | PINxn_STATE].
+             4) Add the pin state to the PORT via [PORTxn_DISABLED | PINxn_STATE].
+       So, PORTx = (0b01100000 & 0b11101111) | ((0b00010000) & (0b11111111)) 
+                 = 0b01100000 | 0b00010000 = 0b01110000 */
+    const volatile uint8_t PORTxn_DISABLED = (*(port.PORTx) & ~(1 << pin));
+    const volatile uint8_t PINxn_STATE = (state && 0xFF) << pin;
+    *(port.PORTx) = PORTxn_DISABLED | PINxn_STATE;
+} 

--- a/shiftavr-core/src/libgpio/port/part/gpio_part.c
+++ b/shiftavr-core/src/libgpio/port/part/gpio_part.c
@@ -1,0 +1,36 @@
+#include <gpio/gpio.h>
+
+void gpio_initialize_ports() {
+    #if defined (__AVR_ATmega32__)
+        /* assign PORTx addresses */
+        GPIO_PORTA.PORTx = &PORTA;
+        GPIO_PORTA.DDRx = &DDRA;
+        GPIO_PORTA.PINx = &PINA;
+
+        GPIO_PORTB.PORTx = &PORTB;
+        GPIO_PORTB.DDRx = &DDRB;
+        GPIO_PORTB.PINx = &PINB;
+
+        GPIO_PORTC.PORTx = &PORTC;
+        GPIO_PORTC.DDRx = &DDRC;
+        GPIO_PORTC.PINx = &PINC;
+
+        GPIO_PORTD.PORTx = &PORTD;
+        GPIO_PORTD.DDRx = &DDRD;
+        GPIO_PORTD.PINx = &PIND;
+        
+    #elif defined (__AVR_ATmega328P__)
+        /* assign PORTx addresses */
+        GPIO_PORTB.PORTx = &PORTB;
+        GPIO_PORTB.DDRx = &DDRB;
+        GPIO_PORTB.PINx = &PINB;
+
+        GPIO_PORTC.PORTx = &PORTC;
+        GPIO_PORTC.DDRx = &DDRC;
+        GPIO_PORTC.PINx = &PINC;
+
+        GPIO_PORTD.PORTx = &PORTD;
+        GPIO_PORTD.DDRx = &DDRD;
+        GPIO_PORTD.PINx = &PIND;
+    #endif
+}

--- a/shiftavr-examples/src/hello_gpio_pollread.c
+++ b/shiftavr-examples/src/hello_gpio_pollread.c
@@ -1,0 +1,22 @@
+/**
+ * @brief An example showing a dirty switch processor which reads the state on PB2 and apply it
+ *        on PB5 on PORTB.
+ * @author pavl_g.
+ * @copyright 
+ *  
+ */
+#define F_CPU 16000000UL
+#include <gpio/gpio.h>
+#include <util/delay.h>
+
+int main() {
+    /* assigns port addresses */
+    gpio_initialize_ports();
+    while (0xFF) {
+        /* reads gpio PB2 Pin with initial Pull-up [OFF] state */
+        const uint8_t state = gpio_read(GPIO_PORTB, PB2, OFF);
+        /* assigns the output state to bit PB5 in PORTB data register */
+        gpio_write(GPIO_PORTB, PB5, state);
+    }
+    return 0;
+}

--- a/shiftavr-examples/src/hello_gpio_write.c
+++ b/shiftavr-examples/src/hello_gpio_write.c
@@ -1,0 +1,23 @@
+/**
+ * @brief An example showing a blink on PB5-PORTB.
+ * @author pavl_g.
+ * @copyright 
+ *  
+ */
+#define F_CPU 16000000UL
+#include <gpio/gpio.h>
+#include <util/delay.h>
+
+int main() {
+    /* assigns the digital port addresses */
+    gpio_initialize_ports();
+    while (0xFF) {
+        /* writes 1 to bit.5 on PORTB data register */
+        gpio_write(GPIO_PORTB, PB5, ON);
+        _delay_ms(500);
+        /* writes 0 to bit.5 on PORTB data register */
+        gpio_write(GPIO_PORTB, PB5, OFF);
+        _delay_ms(500);
+    }
+    return 0;
+}


### PR DESCRIPTION
## This PR adds the following: 
- [x] libgpio: a minimalistic general-purpose IO library.
- [x] hello_gpio_write.c: an example showing a blink on PB5 LED.
- [x] hello_gpio_pollread.c: an example showing a poll-read on a PB2 and assigning the state to PB5 LED. 