### PR TITLE
shift-avr: licensures

### DIFF
--- a/shiftavr-core/src/include/gpio/gpio.h
+++ b/shiftavr-core/src/include/gpio/gpio.h
@@ -1,7 +1,12 @@
 /**
  * @brief The main header entry for the GPIO drivers. 
  * @author pavl_g.
- * @copyright
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #ifndef _GPIO_H_
 #define _GPIO_H_

--- a/shiftavr-core/src/include/gpio/port/part/gpiopart.h
+++ b/shiftavr-core/src/include/gpio/port/part/gpiopart.h
@@ -1,7 +1,12 @@
 /**
  * @brief Defines dependent GPIO registers.
  * @author pavl_g.
- * @copyright
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #ifndef _GPIO_H_
 #   error "The <gpio/port/part/gpiopart.h> header is an internal property, include <gpio/gpio.h> instead of this!"

--- a/shiftavr-core/src/include/gpio/port/part/part-m32.h
+++ b/shiftavr-core/src/include/gpio/port/part/part-m32.h
@@ -1,7 +1,12 @@
 /**
  * @brief Defines GPIO ports for ATMega32.
  * @author pavl_g.
- * @copyright
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #ifndef _GPIO_H_
 #   error "The <gpio/port/part/part-m32.h> header is an internal property, include <gpio/gpio.h> instead of this!"

--- a/shiftavr-core/src/include/gpio/port/part/part-m328p.h
+++ b/shiftavr-core/src/include/gpio/port/part/part-m328p.h
@@ -1,7 +1,12 @@
 /**
  * @brief Defines GPIO ports for ATMega328p.
  * @author pavl_g.
- * @copyright
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #ifndef _GPIO_H_
 #   error "The <gpio/port/part/part-m328p.h> header is an internal property, include <gpio/gpio.h> instead of this!"

--- a/shiftavr-core/src/include/gpio/port/port.h
+++ b/shiftavr-core/src/include/gpio/port/port.h
@@ -3,7 +3,12 @@
  * @note Three I/O memory address locations are allocated for each port, one each for the data register – PORTx, data direction
  *       register – DDRx, and the port input pins – PINx.
  * @author pavl_g.
- * @copyright
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #ifndef _GPIO_H_
 #   error "The <gpio/port/port.h> header is an internal property, include <gpio/gpio.h> instead of this!"

--- a/shiftavr-core/src/include/uart/register/atmega32.h
+++ b/shiftavr-core/src/include/uart/register/atmega32.h
@@ -1,6 +1,12 @@
 /**
  * @brief Defines USART registers for ATmega32 MCU. 
  * @author pavl_g
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #ifndef _ATMEGA_32_H
 #define _ATMEGA_32_H

--- a/shiftavr-core/src/include/uart/register/atmega328p.h
+++ b/shiftavr-core/src/include/uart/register/atmega328p.h
@@ -1,6 +1,13 @@
 /**
  * @brief Defines USART registers for ATmega328p MCU. 
  * @author pavl_g
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
+ * 
  */
 #ifndef _ATMEGA_328p_H
 #define _ATMEGA_328p_H

--- a/shiftavr-core/src/include/uart/uart.h
+++ b/shiftavr-core/src/include/uart/uart.h
@@ -4,8 +4,12 @@
  * @brief Controls the UART IO Protocol which involves sending and receiving bits and firing listeners upon that (Concrete Command pattern).
  * @version 0.1
  * @date 2022-07-02
- * 
- * @copyright The AVR-Sandbox Project, Copyright (c) 2022
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  * 
  */
 #ifndef _UART_H

--- a/shiftavr-examples/src/hello_adc.c
+++ b/shiftavr-examples/src/hello_adc.c
@@ -1,3 +1,13 @@
+/**
+ * @brief An example showing a double-ended ADC software conversion.
+ * @author pavl_g.
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
+ */
 #define F_CPU 16000000UL
 #include <adc/adc.h>
 #include <stdio.h>

--- a/shiftavr-examples/src/hello_gpio_pollread.c
+++ b/shiftavr-examples/src/hello_gpio_pollread.c
@@ -2,8 +2,12 @@
  * @brief An example showing a dirty switch processor which reads the state on PB2 and apply it
  *        on PB5 on PORTB.
  * @author pavl_g.
- * @copyright 
- *  
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #define F_CPU 16000000UL
 #include <gpio/gpio.h>

--- a/shiftavr-examples/src/hello_gpio_write.c
+++ b/shiftavr-examples/src/hello_gpio_write.c
@@ -1,8 +1,12 @@
 /**
  * @brief An example showing a blink on PB5-PORTB.
  * @author pavl_g.
- * @copyright 
- *  
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
  */
 #define F_CPU 16000000UL
 #include <gpio/gpio.h>

--- a/shiftavr-examples/src/hello_uart.c
+++ b/shiftavr-examples/src/hello_uart.c
@@ -1,3 +1,13 @@
+/**
+ * @brief An example showing data transmission and data receive using UART.
+ * @author pavl_g.
+ * @copyright <a href="https://github.com/Software-Hardware-Codesign/ShiftAvr/blob/master/LICENSE"> GPL-v3.0 </a>
+ * GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+ *       The Avr-Sandbox project, ShiftAvr
+ * Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ * Everyone is permitted to copy and distribute verbatim copies 
+ * of this license document, but changing it is not allowed.
+ */
 #define F_CPU 16000000UL
 #include <uart/uart.h>
 


### PR DESCRIPTION
Licensing `shiftavr-core` library headers and examples.